### PR TITLE
Add new fields, correct some

### DIFF
--- a/renogy.js
+++ b/renogy.js
@@ -22,8 +22,8 @@ const renogyValues = {
         //0x103 returns two bytes, one for battery and one for controller temp in c
         const buf = Buffer.alloc(2)
         buf.writeInt16BE(rawData[3]);
-        this.battT = buf[0];
-        this.controlT = buf[1];
+        this.controlT = buf[0];
+        this.battT = buf[1];
         //Register 0x104 - Load Voltage - 4
         this.loadV = (rawData[4] * 0.1).toFixed(2);
         //Register 0x105 - Load Current - 5

--- a/renogy.js
+++ b/renogy.js
@@ -4,7 +4,7 @@ const ModbusRTU = require("modbus-serial");
 const modbusClient = new ModbusRTU();
 
 const dataStartRegister = 0x100;
-const numDataRegisters = 30;
+const numDataRegisters = 34;
 const infoStartRegister = 0x00A;
 const numInfomRegisters = 17;
 
@@ -60,25 +60,47 @@ const renogyValues = {
         //Register 0x115- Controller Uptime (Days) - 21
         this.uptime = rawData[21];
         //Register 0x116- Total Battery Over-charges - 22
-        this.totalBattOvercharge = rawData[22];
+        this.totalBattOverDischarges = rawData[22];
         //Register 0x117- Total Battery Full Charges - 23
         this.totalBattFullCharges = rawData[23];
 
         //Registers 0x118 to 0x119- Total Charging Amp-Hours - 24/25
-        //this.totalChargeAH = rawData[24];
-
+        //We have to combine 4 bytes, two from one register, two from a second register.
+        const bufTotAH = Buffer.alloc(4);
+        bufTotAH.writeUInt16BE(rawData[24]);
+        bufTotAH.writeUInt16BE(rawData[25], 2);
+        this.totalChargeAH = bufTotAH.readUInt32BE();
         //Registers 0x11A to 0x11B- Total Discharging Amp-Hours - 26/27
-        //this.totalChargeAH = rawData[24];
-
+        //We have to combine 4 bytes, two from one register, two from a second register.
+        const bufTotDisAH = Buffer.alloc(4);
+        bufTotDisAH.writeUInt16BE(rawData[26]);
+        bufTotDisAH.writeUInt16BE(rawData[27], 2);
+        this.totalDischargeAH = bufTotDisAH.readUInt32BE();
+		
         //Registers 0x11C to 0x11D- Total Cumulative power generation (kWH) - 28/29
-        //this.totalChargeAH = rawData[24];
+		//We have to combine 4 bytes, two from one register, two from a second register.
+        const bufTotWH = Buffer.alloc(4);
+        bufTotWH.writeUInt16BE(rawData[28]);
+        bufTotWH.writeUInt16BE(rawData[29], 2);
+        this.cumulativePowerGenerated = bufTotWH.readUInt32BE();
 
         //Registers 0x11E to 0x11F- Total Cumulative power consumption (kWH) - 30/31
-        //this.totalChargeAH = rawData[24];
+		//We have to combine 4 bytes, two from one register, two from a second register.
+        const bufTotWHC = Buffer.alloc(4);
+        bufTotWHC.writeUInt16BE(rawData[30]);
+        bufTotWHC.writeUInt16BE(rawData[31], 2);
+        this.cumulativePowerConsumed = bufTotWHC.readUInt32BE();
 
         //Register 0x120 - Load Status, Load Brightness, Charging State - 32
+        //0x120 returns two bytes, one for load status, and one for Charging State.
+        const buf2 = Buffer.alloc(2);
+        buf2.writeUInt16BE(rawData[32]);
+        this.loadStatus = mirror_bits(buf2.readUInt8());  //Seems the bits are completely inverted order?
+        this.chargingState = buf2[1];
 
         //Registers 0x121 to 0x122 - Controller fault codes - 33/34
+        this.FaultCodes = rawData[33];
+		//TODO: Decode fault code(s).
 
         //TODO: More registers
     }
@@ -146,6 +168,16 @@ async function readController(startRegister, numRegisters) {
         logger.error(e);
         process.exit(1);
     }
+}
+
+//Reverses the order of bits given an input integer.
+function mirror_bits(n) {
+    let t = n.toString(2).split('');
+    let str_len = t.length;
+    for (let i = 0; i < 8 - str_len; i++) {
+        t.unshift('0');
+    }
+    return parseInt(t.reverse().join(''), 2);
 }
 
 module.exports = {

--- a/renogy.js
+++ b/renogy.js
@@ -44,7 +44,7 @@ const renogyValues = {
         //Register 0x10D - Max Charge Current Today - 13
         this.chgCMaxToday = (rawData[13] * 0.01).toFixed(2);
         //Register 0x10E - Max Discharge Current Today - 14
-        this.dischgCMaxToday = (rawData[14] * 0.1).toFixed(2);
+        this.dischgCMaxToday = (rawData[14] * 0.01).toFixed(2);
         //Register 0x10F - Max Charge Power Today - 15 
         this.chgPMaxToday = (rawData[15]).toFixed(2);
         //Register 0x110- Max Discharge Power Today - 16


### PR DESCRIPTION
I had need of reading the charging mode from my device, (Idle, MPPT, Boost, Float, etc) so I dug into the documentation, and extended your project.

Changes:

- Swapped battery temperature & Controller temperature.  (They were backwards)
- dischgCMaxToday was multiplied by wrong factor.  (Based on documentation, verified by testing)
- Added "totalChargeAH", "totalDischargeAH", "cumulativePowerGenerated", "cumulativePowerConsumed", "loadStatus", "chargingState", "FaultCodes"

Notes:
chargingState & loadStatus were tested very well.  (They were my main goal in updating this)
Faultcodes does not have any decoding done, just reports the raw number for now.
4 of the new fields use multiple registers of 2 bytes each to store the values, as they are long-term incrementing registers.  My device is fairly new, so I cannot properly test if my combining of multiple registers is done correctly.  If anyone has had a device for long enough that those total/cumulative fields require more than 2 bytes, I would appreciate your feedback to know if I am decoding those fields correctly or not.